### PR TITLE
fix: configure S3 bucket for public access in LocalStack

### DIFF
--- a/client/src/components/FileDropzone.tsx
+++ b/client/src/components/FileDropzone.tsx
@@ -43,7 +43,8 @@ export const FileDropzone = ({
       <input
         ref={fileInputRef}
         type="file"
-        accept=".pdf,.docx,.md"
+        accept=".pdf,.docx,.md,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,text/markdown"
+        multiple
         onChange={onFileInput}
         className="hidden"
       />

--- a/client/src/components/FileList.tsx
+++ b/client/src/components/FileList.tsx
@@ -20,7 +20,6 @@ const formatFileSize = (bytes: number): string => {
 };
 
 const getFileIcon = (fileName: string) => {
-  const extension = fileName.split(".").pop()?.toLowerCase();
   return <FileText className="h-5 w-5 text-primary" />;
 };
 
@@ -28,7 +27,7 @@ const getFileTypeBadge = (fileName: string) => {
   const extension = fileName.split(".").pop()?.toLowerCase();
   return (
     <Badge variant="secondary" className="text-xs">
-      {extension?.toUpperCase()}
+      {extension?.toUpperCase() || "FILE"}
     </Badge>
   );
 };
@@ -38,16 +37,7 @@ export const FileList = ({
   onRemove,
   isLoading = false,
 }: FileListProps) => {
-  if (isLoading) {
-    return (
-      <div className="text-center py-12">
-        <Loader2 className="h-12 w-12 text-muted-foreground mx-auto mb-4 animate-spin" />
-        <p className="text-muted-foreground">Loading files...</p>
-      </div>
-    );
-  }
-
-  if (files.length === 0) {
+  if (files.length === 0 && !isLoading) {
     return (
       <div className="text-center py-12">
         <File className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
@@ -62,9 +52,10 @@ export const FileList = ({
         Uploaded Files ({files.length})
       </h3>
 
-      {files.map((file) => (
-        <a key={file.id} target="_blank" href={file.public_url}>
-          <Card className="p-4 hover:shadow-md transition-shadow cursor-pointer">
+      {files.map((file) => {
+        // Don't make it a link if file is still uploading or doesn't have a URL yet
+        const fileContent = (
+          <Card className={`p-4 transition-shadow ${file.public_url && !file.isUploading ? 'hover:shadow-md cursor-pointer' : ''}`}>
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-3 flex-1 min-w-0">
                 {file.isUploading || file.isDeleting ? (
@@ -122,8 +113,19 @@ export const FileList = ({
               </Button>
             </div>
           </Card>
-        </a>
-      ))}
+        );
+
+        // Only wrap in link if file has a public URL and is not uploading
+        if (file.public_url && !file.isUploading) {
+          return (
+            <a key={file.id} target="_blank" href={file.public_url} rel="noopener noreferrer">
+              {fileContent}
+            </a>
+          );
+        }
+
+        return <div key={file.id}>{fileContent}</div>;
+      })}
     </div>
   );
 };

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="min-h-screen w-full flex items-center justify-center bg-background">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto"></div>
           <p className="mt-4 text-muted-foreground">Loading...</p>

--- a/client/src/hooks/useFileUpload.ts
+++ b/client/src/hooks/useFileUpload.ts
@@ -1,7 +1,7 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/hooks/use-toast';
-import { fileApi } from '@/lib/api';
+import { fileApi, UploadedFileResponse } from '@/lib/api';
 
 export interface UploadedFile {
   id: string;
@@ -46,8 +46,20 @@ export const useFileUpload = () => {
   const uploadMutation = useMutation({
     mutationFn: ({ file, onProgress }: { file: File; onProgress: (progress: number) => void }) =>
       fileApi.uploadFile(file, onProgress),
-    onSuccess: () => {
+    onSuccess: (response) => {
+      // Optimistically update the query cache with the new file (in raw API response format, before select)
+      queryClient.setQueryData<UploadedFileResponse[]>(['uploadedFiles'], (oldFiles = []) => {
+        // Check if file already exists to avoid duplicates
+        const exists = oldFiles.some(f => f.object_key === response.object_key || f.filename === response.filename);
+        if (exists) {
+          return oldFiles;
+        }
+        return [...oldFiles, response];
+      });
+      
+      // Then invalidate to refetch and confirm
       queryClient.invalidateQueries({ queryKey: ['uploadedFiles'] });
+      
       toast({
         title: "File uploaded",
         description: "File uploaded successfully to server",
@@ -83,9 +95,36 @@ export const useFileUpload = () => {
     },
   });
 
-  // Combine local and server files
+  // Remove local files that have appeared in serverFiles
+  useEffect(() => {
+    if (serverFiles.length > 0 && localFiles.length > 0) {
+      setLocalFiles(prev => {
+        const serverFileNames = new Set(serverFiles.map(f => f.name));
+        return prev.filter(localFile => {
+          // Keep if still uploading, otherwise remove if it's in serverFiles
+          return localFile.isUploading || !serverFileNames.has(localFile.name);
+        });
+      });
+    }
+  }, [serverFiles]);
+
+  // Combine local and server files, avoiding duplicates
   const uploadedFiles = useMemo(() => {
-    return [...localFiles, ...(serverFiles.map(item => item.object_key === deletingFileObjectKey ? {...item, isDeleting: true} : item) || [])]
+    const serverFileNames = new Set(serverFiles.map(f => f.name));
+    
+    // Only show local files that don't exist in serverFiles yet
+    const activeLocalFiles = localFiles.filter(localFile => {
+      return !serverFileNames.has(localFile.name);
+    });
+    
+    // Combine with server files, marking deleting ones
+    const processedServerFiles = serverFiles.map(item => 
+      item.object_key === deletingFileObjectKey 
+        ? {...item, isDeleting: true} 
+        : item
+    );
+    
+    return [...activeLocalFiles, ...processedServerFiles];
   }, [localFiles, serverFiles, deletingFileObjectKey])
 
   const validateFile = useCallback((file: File): string | null => {
@@ -135,9 +174,13 @@ export const useFileUpload = () => {
         ));
       }
     }, {
-      onSuccess: () => {
-      // Remove from local files as it will come from server files
-        setLocalFiles(prev => prev.filter(f => f.id !== tempId));
+      onSuccess: (response) => {
+        // Mark as not uploading but keep in localFiles until it appears in serverFiles
+        setLocalFiles(prev => prev.map(f => 
+          f.id === tempId 
+            ? { ...f, isUploading: false, uploadProgress: 100 }
+            : f
+        ));
       },
       onError: () => {
         // Remove failed upload from local files

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -144,7 +144,10 @@ const Index = () => {
         <SidebarContent>
           <SidebarMenu>
             {conversationsLoading ? (
-              <div className="p-4 text-sm text-muted-foreground">Loading...</div>
+              <div className="p-4 flex flex-col items-center justify-center">
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary mb-2"></div>
+                <div className="text-sm text-muted-foreground">Loading conversations...</div>
+              </div>
             ) : conversations.length === 0 ? (
               <div className="p-4 text-sm text-muted-foreground text-center">
                 No conversations yet. Start a new one!

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -63,8 +63,9 @@ async def health_check():
 async def upload(file: UploadFile, current_user: dict = Depends(get_current_user)):
     """Upload and process ADR document"""
     try:
-        result = await adr_service.process_adr(file)
-        return {"message": "ADR processed successfully", "doc_id": result}
+        doc_ids, file_info = await adr_service.process_adr(file)
+        # Return file information in the format expected by the frontend
+        return file_info
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/server/app/services/adr_service.py
+++ b/server/app/services/adr_service.py
@@ -437,6 +437,27 @@ class ADRService:
 
         for doc in unique_docs:
             metadata: Dict[str, Any] = doc.metadata
+            s3_uri = metadata.get("s3_uri", "Unknown")
+            
+            # Regenerate public_url from s3_uri to ensure it uses the correct endpoint (LocalStack or AWS)
+            # s3_uri format: s3://bucket-name/object-key
+            public_url = "Unknown"
+            if s3_uri != "Unknown" and s3_uri.startswith("s3://"):
+                try:
+                    # Extract object_key from s3_uri (everything after s3://bucket-name/)
+                    parts = s3_uri.replace("s3://", "").split("/", 1)
+                    if len(parts) == 2:
+                        object_key = parts[1]
+                        # Use uploader_service to generate the correct URL
+                        public_url = self.uploader_service._get_public_url(object_key)
+                except Exception as e:
+                    print(f"Warning: Could not regenerate URL from s3_uri {s3_uri}: {e}")
+                    # Fallback to stored public_url if regeneration fails
+                    public_url = metadata.get("public_url", "Unknown")
+            else:
+                # Fallback to stored public_url if s3_uri is invalid
+                public_url = metadata.get("public_url", "Unknown")
+            
             ref: Dict[str, str] = {
                 "filename": metadata.get("filename", "Unknown"),
                 "adr_number": metadata.get("adr_number", "Unknown"),
@@ -445,8 +466,8 @@ class ADRService:
                 "author": metadata.get("author", "Unknown"),
                 "date": metadata.get("date", "Unknown"),
                 "source": metadata.get("source", "N/A"),
-                "public_url": metadata.get("public_url", "Unknown"),
-                "s3_uri": metadata.get("s3_uri", "Unknown"),
+                "public_url": public_url,
+                "s3_uri": s3_uri,
             }
             references.append(ref)
         return references

--- a/server/app/services/adr_service.py
+++ b/server/app/services/adr_service.py
@@ -16,7 +16,8 @@ from app.utils.text_cleaner import (
 import pypdfium2 as pdfium
 import docx
 from io import BytesIO
-from typing import Dict, List, Optional, Any, Union, Set
+from typing import Dict, List, Optional, Any, Union, Set, Tuple
+from datetime import datetime
 from botocore.exceptions import ClientError
 
 from app.config.settings import settings
@@ -49,7 +50,7 @@ class ADRService:
         self.extraction_chain = ExtractionChain()
         self.uploader_service = UploaderService()
 
-    async def process_adr(self, file: UploadFile) -> List[str]:
+    async def process_adr(self, file: UploadFile) -> Tuple[List[str], Dict[str, Any]]:
         """
         Process uploaded ADR and add to knowledge base.
 
@@ -57,7 +58,7 @@ class ADRService:
             file: The uploaded file to process
 
         Returns:
-            List of document IDs added to the vector store
+            Tuple of (List of document IDs added to the vector store, File information dict)
 
         Raises:
             HTTPException: If any step of processing fails
@@ -145,8 +146,17 @@ class ADRService:
 
             doc_ids = self.vector_store.add_documents(splits)
 
-            # Return all document IDs
-            return doc_ids
+            # Prepare file information for response
+            file_info = {
+                "object_key": s3_object_name,
+                "filename": file_name,
+                "size_bytes": len(content),
+                "last_modified": datetime.utcnow().isoformat() + "+00:00",
+                "permanent_url": public_url
+            }
+
+            # Return document IDs and file information
+            return doc_ids, file_info
 
         except Exception as e:
             # Handle failures during vector store indexing

--- a/server/app/services/s3_client.py
+++ b/server/app/services/s3_client.py
@@ -26,12 +26,33 @@ class S3Client:
             cls._instance.client = boto3.client("s3", **client_kwargs)
             
             # Create bucket if using LocalStack and bucket doesn't exist
+            # Also ensure bucket is public for LocalStack
             if settings.AWS_ENDPOINT_URL:
+                bucket_exists = False
                 try:
                     cls._instance.client.head_bucket(Bucket=settings.S3_BUCKET_NAME)
+                    bucket_exists = True
                 except cls._instance.client.exceptions.ClientError:
                     # Bucket doesn't exist, create it
                     cls._instance.client.create_bucket(Bucket=settings.S3_BUCKET_NAME)
+                
+                # Make bucket public for LocalStack (whether it existed or was just created)
+                try:
+                    # Disable block public access
+                    cls._instance.client.delete_public_access_block(
+                        Bucket=settings.S3_BUCKET_NAME
+                    )
+                except cls._instance.client.exceptions.ClientError:
+                    pass  # May not exist, that's fine
+                
+                # Set bucket ACL to public-read
+                try:
+                    cls._instance.client.put_bucket_acl(
+                        Bucket=settings.S3_BUCKET_NAME,
+                        ACL="public-read"
+                    )
+                except cls._instance.client.exceptions.ClientError:
+                    pass  # May fail, but that's okay
         return cls._instance
 
     def get_client(self):

--- a/server/app/services/uploader_service.py
+++ b/server/app/services/uploader_service.py
@@ -75,11 +75,16 @@ class UploaderService:
             print(
                 f"Uploading file-like object to S3 bucket '{self.bucket_name}' as '{object_name}'..."
             )
+            # Set ACL to public-read for LocalStack compatibility
+            extra_args = {
+                "ContentType": content_type,
+                "ACL": "public-read"
+            }
             self.s3_client.upload_fileobj(
                 file_obj,
                 self.bucket_name,
                 object_name,
-                ExtraArgs={"ContentType": content_type},
+                ExtraArgs=extra_args,
             )
             s3_uri = self.get_s3_uri(object_name)
             public_url = self._get_public_url(object_name)
@@ -176,4 +181,17 @@ class UploaderService:
         # Ensure the object key is URL-encoded for special characters
         encoded_object_key = quote(object_key, safe="/")
 
-        return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{encoded_object_key}"
+        # Use LocalStack endpoint if configured, otherwise use AWS S3 format
+        if settings.AWS_ENDPOINT_URL:
+            # For LocalStack, construct URL using the endpoint
+            endpoint = settings.AWS_ENDPOINT_URL.rstrip('/')
+            # Convert 'localstack' hostname to 'localhost' for browser access
+            # This handles the case where the endpoint is http://localstack:4566
+            # but browsers need http://localhost:4566
+            if 'localstack' in endpoint and 'localhost' not in endpoint:
+                endpoint = endpoint.replace('localstack', 'localhost')
+            # LocalStack format: http://localhost:4566/bucket-name/object-key
+            return f"{endpoint}/{self.bucket_name}/{encoded_object_key}"
+        else:
+            # AWS S3 format
+            return f"https://{self.bucket_name}.s3.{self.region}.amazonaws.com/{encoded_object_key}"


### PR DESCRIPTION
**Description**

- Generate LocalStack URLs instead of AWS S3 URLs when endpoint is configured
- Automatically set bucket and object ACLs to public-read for LocalStack
- Regenerate URLs from s3_uri in query references to fix stored AWS URLs